### PR TITLE
adjusted the sort order of productSearch

### DIFF
--- a/poco/apps/apis/search/tests.py
+++ b/poco/apps/apis/search/tests.py
@@ -47,20 +47,30 @@ class ItemsSearchViewSortByStockTest(BaseAPITest):
         self.assertEqual([rec["item_id"] for rec in response.data["records"]], ["I124", "I123"])
 
     def test_search(self):
-        items = [{"type": "product",
-                  "item_id": "I123",
-                  "item_name": "超级tian能恩",
-                  "item_link": "abc",
-                  "available": True,
-                  "stock": 1
+        items = [{
+                     "type": "product",
+                     "item_id": "I123",
+                     "item_name": "超级tian能恩",
+                     "item_link": "abc",
+                     "available": True,
+                     "stock": 1
                  },
-                 {"type": "product",
-                                   "item_id": "I124",
-                                   "item_name": "能恩",
-                                   "item_link": "abc",
-                                   "stock": 0,
-                                   "available": True
-                                  },
+                 {
+                     "type": "product",
+                     "item_id": "I124",
+                     "item_name": "能恩",
+                     "item_link": "abc",
+                     "stock": 0,
+                     "available": True
+                 },
+                 {
+                     "type": "product",
+                     "item_id": "I125",
+                     "item_name": "能恩",
+                     "item_link": "abc",
+                     "stock": 1,
+                     "available": True
+                 },
                  ]
         class A:
             def getItems(*args):
@@ -78,15 +88,15 @@ class ItemsSearchViewSortByStockTest(BaseAPITest):
             settings.SEARCH_RESULT_ORDER_BY_STOCK = False
 
             response = self.api_post(reverse("products-search"), data=body)
-            self.assertEqual(response.data["info"]["total_result_count"], 2)
-            self.assertEqual([rec["item_id"] for rec in response.data["records"]], ["I124", "I123"])
+            self.assertEqual(response.data["info"]["total_result_count"], 3)
+            self.assertEqual([rec["item_id"] for rec in response.data["records"]][2], "I123")
 
             self.clearCaches()
             settings.SEARCH_RESULT_ORDER_BY_STOCK = True
 
             response = self.api_post(reverse("products-search"), data=body)
-            self.assertEqual(response.data["info"]["total_result_count"], 2)
-            self.assertEqual([rec["item_id"] for rec in response.data["records"]], ["I123", "I124"])
+            self.assertEqual(response.data["info"]["total_result_count"], 3)
+            self.assertEqual([rec["item_id"] for rec in response.data["records"]], ["I125", "I124", "I123"])
         finally:
             settings.SEARCH_RESULT_ORDER_BY_STOCK = origin_search_result_order_by_stock
 

--- a/poco/apps/apis/search/views.py
+++ b/poco/apps/apis/search/views.py
@@ -113,7 +113,7 @@ class ProductsSearch(BaseAPIView):
         if sort_fields == []:
             sort_fields = ["_score"]
 
-        sort_fields = order_by_stock + sort_fields
+        sort_fields = sort_fields + order_by_stock
 
         s = s.order_by(*sort_fields)
 


### PR DESCRIPTION
针对 #116 ， 将库存排序放到后面，在评分（或其它排序条件）一致基础上，再针对商品库存进行排序

@lisztli ，麻烦Review一下
